### PR TITLE
Added AHE key validity checks

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -15,9 +15,11 @@ use curv::cryptographic_primitives::commitments::traits::Commitment;
 use curv::elliptic::curves::traits::{ECPoint, ECScalar};
 use curv::{BigInt, FE, GE};
 use paillier::{
-    Decrypt, DecryptionKey, EncryptionKey, KeyGeneration, Paillier, RawCiphertext, RawPlaintext,
+    is_prime, Decrypt, DecryptionKey, EncryptionKey, KeyGeneration, Paillier, RawCiphertext,
+    RawPlaintext,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
@@ -225,6 +227,13 @@ impl PaillierKeys {
     /// decrypts given value `c`
     pub fn decrypt(&self, c: BigInt) -> RawPlaintext {
         Paillier::decrypt(&self.dk, &RawCiphertext::from(c))
+    }
+
+    pub fn is_valid(ek: &EncryptionKey, dk: &DecryptionKey) -> bool {
+        is_prime(&dk.p)
+            && is_prime(&dk.q)
+            && ek.n == dk.p.borrow() * dk.q.borrow()
+            && ek.nn == ek.n.pow(2)
     }
 }
 

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -24,6 +24,7 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::atomic;
+use trace::trace;
 use zeroize::Zeroize;
 
 pub mod keygen;
@@ -229,7 +230,10 @@ impl PaillierKeys {
         Paillier::decrypt(&self.dk, &RawCiphertext::from(c))
     }
 
+    /// checks whether Paillier's setup is valid and consistent
+    #[trace(pretty, prefix = "PaillierKeys::")]
     pub fn is_valid(ek: &EncryptionKey, dk: &DecryptionKey) -> bool {
+        // TODO : report back specific errors
         is_prime(&dk.p)
             && is_prime(&dk.q)
             && ek.n == dk.p.borrow() * dk.q.borrow()


### PR DESCRIPTION
Few essential Paillier encryption setup checks are added. The goal is to validate the setup before its first use. The assumptions are: an incorrect setup can be given to keygen or loaded from wallet by the signing protocol, as well as wrong {p,q} can be loaded via secret loader to keygen.
